### PR TITLE
get Q&A soporta QUERY productQAndAId

### DIFF
--- a/api/src/routes/Q&A.js
+++ b/api/src/routes/Q&A.js
@@ -8,8 +8,15 @@ const router = Router();
 
 router
   .get("/", async (req, res) => {
+    const {productQAndAId} = req.query
+    let where = {}
     try {
-      const qA = await QandA.findAll({ order: ["id"] , include:{
+      if (productQAndAId) {
+        where = {
+          productQAndAId,
+        }
+      }
+      const qA = await QandA.findAll({ order: ["id"] , where, include:{
         model: Product,
         as: "productQAndA"
       }});


### PR DESCRIPTION
Q&A get soporta QUERY productQAndAId.
Le pasás el query y te trae solo los bloques de Q&A del producto consultado.
Si pasás un ID inexistente o de un producto que no tiene Q&As, devuelve un array vacío